### PR TITLE
Quoting edges names, as dot does not like names with dots. Fixing problem with "ret void" displaying. Switched to nicer rectangular shapes.

### DIFF
--- a/graph-llvm-ir
+++ b/graph-llvm-ir
@@ -63,7 +63,7 @@ class Graph:
         self.write('label="Black edges - dataflow, red edges - control flow"')
 
     def edge(self, fro, to, extra=""):
-        self.edges.append("%s -> %s%s" % (fro, to, extra))
+        self.edges.append("\"%s\" -> \"%s\"%s" % (fro, to, extra))
 
     def block_name(self, b):
         """Returns basic block name, i.e. its entry label, or made name
@@ -97,12 +97,12 @@ class Graph:
                     name = self.block_name(b)
 #                    if not self.options.block_edges_helpers:
                     if 1:
-                        self.write("subgraph cluster_%s {" % name)
+                        self.write("subgraph \"cluster_%s\" {" % name)
 
                     if not self.options.block_edges:
-                        self.write('%s [label="label: %s"]' % (name, name))
+                        self.write('\"%s\" [label="label: \"%s\""]' % (name, name))
                     elif self.options.block_edges_helpers:
-                        self.write('%s [shape=point height=0.02 width=0.02 color=red fixedsize=true]' % name)
+                        self.write('\"%s\" [shape=point height=0.02 width=0.02 color=red fixedsize=true]' % name)
 
 #                    if not self.options.block_edges_helpers:
                     if 1:
@@ -119,12 +119,12 @@ class Graph:
             block_name = self.block_name(b)
             self.edges = []
             if self.options.block:
-                self.write("subgraph cluster_%s {" % block_name)
+                self.write("subgraph \"cluster_%s\" {" % block_name)
                 self.write("label=%s" % block_name)
 #            if not self.options.block_edges:
-#                self.write('%s [label="label: %s"]' % (block_name, block_name))
+#                self.write('\"%s\" [label="label: %s"]' % (block_name, block_name))
 #           elif self.options.block_edges_helpers:
-#               self.write('%s [shape=point]' % (b.name))
+#               self.write('\"%s\" [shape=point]' % (b.name))
 
             # Create block entry label node and edge from it to first IR instruction
             if not self.options.block_edges or self.options.block_edges_helpers:
@@ -132,9 +132,13 @@ class Graph:
                 if b.name == "entry":
                     attr += "[weight=5]"
                 if self.options.block_edges:
-                    attr += "[lhead=cluster_%s]" % block_name
+                    attr += "[lhead=\"cluster_%s\"]" % block_name
                 if self.options.control:
-                    self.edge(block_name, b.instructions[0].name, attr)
+                    if b.instructions[0].name == "":
+                        n = self.instr_name(b.instructions[0])
+                        self.edge(block_name, n, attr)
+                    else:
+                        self.edge(block_name, b.instructions[0].name, attr)
 
             if self.options.dag_control:
                 last_void_inst = block_name
@@ -148,7 +152,7 @@ class Graph:
             last_inst_name = None
             for i in b.instructions:
                 n = self.instr_name(i)
-                self.write('%s [label="%s"]' % (n, i))
+                self.write('\"%s\" [label="%s"]' % (n, i))
                 if self.options.control:
                     if last_inst_name:
                         self.edge(last_inst_name, n, "[color=red weight=2]")
@@ -158,7 +162,7 @@ class Graph:
 
                 for a in i.operands:
                         if isinstance(a, Constant) and not a.name:
-                            arg_val = '"%s"' % a
+                            arg_val = a
                         else:
                             arg_val = a.name
                         if i.opcode_name == "br" and type(a) is BasicBlock:
@@ -167,7 +171,7 @@ class Graph:
                                 arg_val = a.instructions[0].name
                             attrs = "[color=red]"
                             if self.options.block_edges:
-                                attrs += "[color=red][lhead=cluster_%s][ltail=cluster_%s][weight=5]" % (a.name, block_name)
+                                attrs += "[color=red][lhead=\"cluster_%s\"][ltail=\"cluster_%s\"][weight=5]" % (a.name, block_name)
                                 if self.options.block_edges_helpers:
                                     attrs += "[arrowhead=none]"
                             self.edge(n, arg_val, attrs)


### PR DESCRIPTION
Tried graph-llvm-ir on the llvm code below and fixed several minor issues encountered.

$ cat example.ll
; ModuleID = '/home/marcusmae/Documents/llvm-graphs/example/example.c'
target datalayout = "e-p:64:64:64-i1:8:8-i8:8:8-i16:16:16-i32:32:32-i64:64:64-f32:32:32-f64:64:64-v64:64:64-v128:128:128-a0:0:64-s0:64:64-f80:128:128-n8:16:32:64-S128"
target triple = "x86_64-unknown-linux-gnu"

define void @vector_sum(i32 %length, float\* nocapture %in1, float\* nocapture %in2, float\* nocapture %out) nounwind uwtable {
entry:
  %cmp9 = icmp sgt i32 %length, 0
  br i1 %cmp9, label %for.body, label %for.end

for.body:                                         ; preds = %entry, %for.body
  %indvars.iv = phi i64 [ %indvars.iv.next, %for.body ], [ 0, %entry ]
  %arrayidx = getelementptr inbounds float\* %in1, i64 %indvars.iv
  %0 = load float\* %arrayidx, align 4, !tbaa !0
  %arrayidx2 = getelementptr inbounds float\* %in2, i64 %indvars.iv
  %1 = load float\* %arrayidx2, align 4, !tbaa !0
  %add = fadd float %0, %1
  %arrayidx4 = getelementptr inbounds float\* %out, i64 %indvars.iv
  store float %add, float\* %arrayidx4, align 4, !tbaa !0
  %indvars.iv.next = add i64 %indvars.iv, 1
  %lftr.wideiv = trunc i64 %indvars.iv.next to i32
  %exitcond = icmp eq i32 %lftr.wideiv, %length
  br i1 %exitcond, label %for.end, label %for.body

for.end:                                          ; preds = %for.body, %entry
  ret void
}

define i32 @main(i32 %argc, i8*\* nocapture %argv) nounwind uwtable {
entry:
  %cmp = icmp eq i32 %argc, 2
  br i1 %cmp, label %if.end, label %return

if.end:                                           ; preds = %entry
  %arrayidx = getelementptr inbounds i8*\* %argv, i64 1
  %0 = load i8*\* %arrayidx, align 8, !tbaa !3
  %call = tail call i32 @atoi(i8\* %0) nounwind readonly
  %conv = sext i32 %call to i64
  %mul = shl nsw i64 %conv, 2
  %call1 = tail call noalias i8\* @malloc(i64 %mul) nounwind
  %1 = bitcast i8\* %call1 to float*
  %call4 = tail call noalias i8\* @malloc(i64 %mul) nounwind
  %2 = bitcast i8\* %call4 to float*
  %call7 = tail call noalias i8\* @malloc(i64 %mul) nounwind
  %3 = bitcast i8\* %call7 to float*
  %cmp826 = icmp sgt i32 %call, 0
  br i1 %cmp826, label %for.body, label %for.end

for.body:                                         ; preds = %if.end, %for.body
  %indvars.iv = phi i64 [ %indvars.iv.next, %for.body ], [ 0, %if.end ]
  %call10 = tail call double @drand48() nounwind
  %conv11 = fptrunc double %call10 to float
  %arrayidx12 = getelementptr inbounds float\* %1, i64 %indvars.iv
  store float %conv11, float\* %arrayidx12, align 4, !tbaa !0
  %call13 = tail call double @drand48() nounwind
  %conv14 = fptrunc double %call13 to float
  %arrayidx16 = getelementptr inbounds float\* %2, i64 %indvars.iv
  store float %conv14, float\* %arrayidx16, align 4, !tbaa !0
  %indvars.iv.next = add i64 %indvars.iv, 1
  %lftr.wideiv = trunc i64 %indvars.iv.next to i32
  %exitcond = icmp eq i32 %lftr.wideiv, %call
  br i1 %exitcond, label %for.end, label %for.body

for.end:                                          ; preds = %for.body, %if.end
  tail call void @vector_sum(i32 %call, float\* %1, float\* %2, float\* %3)
  br label %return

return:                                           ; preds = %entry, %for.end
  %retval.0 = phi i32 [ 0, %for.end ], [ 1, %entry ]
  ret i32 %retval.0
}

define available_externally i32 @atoi(i8\* nocapture %__nptr) nounwind uwtable readonly inlinehint {
entry:
  %call = tail call i64 @strtol(i8\* nocapture %__nptr, i8*\* null, i32 10) nounwind
  %conv = trunc i64 %call to i32
  ret i32 %conv
}

declare noalias i8\* @malloc(i64) nounwind

declare double @drand48() nounwind

declare i64 @strtol(i8_, i8_\* nocapture, i32) nounwind

!0 = metadata !{metadata !"float", metadata !1}
!1 = metadata !{metadata !"omnipotent char", metadata !2}
!2 = metadata !{metadata !"Simple C/C++ TBAA"}
!3 = metadata !{metadata !"any pointer", metadata !1}
